### PR TITLE
Add Rails >= 5.1 support

### DIFF
--- a/app/controllers/redsys/tpv_controller.rb
+++ b/app/controllers/redsys/tpv_controller.rb
@@ -1,6 +1,6 @@
 module Redsys
   class TpvController < ApplicationController
-    skip_before_filter :verify_authenticity_token, only: [:confirmation]
+    skip_before_action :verify_authenticity_token, only: [:confirmation]
 
     #
     # Formulario de salto a la pasarela de pago

--- a/app/controllers/redsys/tpv_controller.rb
+++ b/app/controllers/redsys/tpv_controller.rb
@@ -24,6 +24,6 @@ module Redsys
       gateway = params[:gateway]
       @tpv = Redsys::Tpv.new(amount, order, language, merchant_url, url_ok, url_ko, merchant_name, product_description, gateway)
     end
-    
+
   end
 end

--- a/app/controllers/redsys/tpv_controller.rb
+++ b/app/controllers/redsys/tpv_controller.rb
@@ -13,7 +13,7 @@ module Redsys
     # - url_ko:string => url de vuelta del tpv cuando ocurre un error
     #
     def form
-      amount = BigDecimal.new(params[:amount] || '0')
+      amount = BigDecimal(params[:amount] || '0')
       order = params[:order] || '0'
       language = params[:language]
       url_ok = params[:url_ok]

--- a/lib/generators/templates/controllers/notifications_controller.rb
+++ b/lib/generators/templates/controllers/notifications_controller.rb
@@ -9,11 +9,11 @@ module Redsys
     def notification
       json_params = JSON.parse(Base64.urlsafe_decode64(params[:Ds_MerchantParameters]))
       #TODO: Can't make this call work nor in ruby 1.8.7 neither in ruby 2.3.0, so I create an instance of the TPV class just for checking the signature
-      
+
       # We need recover from notification response our "gateway_value". This "gateway_value" is same that we util when initialize our request on controller.
       # Example: gateway_value = PaymentRequest.find_by(tpv_order_id: json_params["Ds_Order"].to_i).gateway
       # PaymentRequest is our model where we save all information from order request.
-      @tpv = Redsys::Tpv.new(json_params["Ds_Amount"], json_params["Ds_Order"], json_params["Ds_ConsumerLanguage"],'','','','','', gateway_value)      
+      @tpv = Redsys::Tpv.new(json_params["Ds_Amount"], json_params["Ds_Order"], json_params["Ds_ConsumerLanguage"],'','','','','', gateway_value)
       if @tpv.response_signature(params[:Ds_MerchantParameters]) == params[:Ds_Signature] && json_params["Ds_Response"].present?
         # Enter only if the signature from the gateway is correct
         if (json_params["Ds_Response"].to_i >= 0 && json_params["Ds_Response"].to_i <= 99)

--- a/lib/generators/templates/controllers/notifications_controller.rb
+++ b/lib/generators/templates/controllers/notifications_controller.rb
@@ -1,6 +1,6 @@
 module Redsys
   class NotificationsController < ApplicationController
-    skip_before_filter :verify_authenticity_token
+    skip_before_action :verify_authenticity_token
 
     #
     # Tratamiento para la notificación online

--- a/many-redsys-rails.gemspec
+++ b/many-redsys-rails.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "rails", ">= 4.0.2"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
# Objective
Make gem work with Rails >= 5.1

Drop support for Rails versions lower than 4.0.2.

# How
Use `skip_before_action` method instead of `skip_before_filter` removed since Rails 5.1.
